### PR TITLE
Modify subcategoryBreakdown to include parent category in landscape_stats.json

### DIFF
--- a/generated/landscape_stats.json
+++ b/generated/landscape_stats.json
@@ -1,6 +1,6 @@
 {
   "cncfProjectsSummary": {
-    "count": 181,
+    "count": 183,
     "commonKeys": [
       "item",
       "name",
@@ -16,44 +16,60 @@
     "uniqueKeys": "additional_repos,additional_repos.0,additional_repos.0.repo_url,additional_repos.1,additional_repos.1.repo_url,additional_repos.10,additional_repos.10.repo_url,additional_repos.11,additional_repos.11.repo_url,additional_repos.12,additional_repos.12.repo_url,additional_repos.13,additional_repos.13.repo_url,additional_repos.14,additional_repos.14.repo_url,additional_repos.15,additional_repos.15.repo_url,additional_repos.16,additional_repos.16.repo_url,additional_repos.2,additional_repos.2.repo_url,additional_repos.3,additional_repos.3.repo_url,additional_repos.4,additional_repos.4.repo_url,additional_repos.5,additional_repos.5.repo_url,additional_repos.6,additional_repos.6.repo_url,additional_repos.7,additional_repos.7.repo_url,additional_repos.8,additional_repos.8.repo_url,additional_repos.9,additional_repos.9.repo_url,allow_duplicate_repo,description,enduser,extra.annual_review_date,extra.annual_review_url,extra.archived,extra.artwork_url,extra.audits,extra.audits.0,extra.audits.0.date,extra.audits.0.type,extra.audits.0.url,extra.audits.0.vendor,extra.audits.1,extra.audits.1.date,extra.audits.1.type,extra.audits.1.url,extra.audits.1.vendor,extra.audits.2,extra.audits.2.date,extra.audits.2.type,extra.audits.2.url,extra.audits.2.vendor,extra.blog_url,extra.chat_channel,extra.clomonitor_name,extra.cncf_tags,extra.cncf_tags.0,extra.dev_stats_url,extra.devstats,extra.docker_url,extra.github_discussions_url,extra.gitter_url,extra.graduated,extra.incubating,extra.mailing_list_url,extra.slack_url,extra.specification,extra.stack_overflow_url,extra.summary_business_use_case,extra.summary_integration,extra.summary_integrations,extra.summary_intro_url,extra.summary_languages,extra.summary_personas,extra.summary_release_rate,extra.summary_tags,extra.summary_use_case,extra.url_for_bestpractices,extra.youtube_url,joined,open_source,project_org,repo_url,second_path,second_path.0,second_path.1,twitter,url_for_bestpractices",
     "categoryBreakdown": {
       "Provisioning": 45,
-      "Runtime": 28,
+      "Runtime": 29,
       "Orchestration & Management": 39,
       "App Definition and Development": 38,
       "Platform": 2,
       "Serverless": 6,
-      "Observability and Analysis": 21,
+      "Observability and Analysis": 22,
       "Wasm": 2
     },
     "subcategoryBreakdown": {
-      "Automation & Configuration": 13,
-      "Container Registry": 4,
-      "Security & Compliance": 24,
-      "Key Management": 4,
-      "Cloud Native Storage": 11,
-      "Container Runtime": 8,
-      "Cloud Native Network": 9,
-      "Scheduling & Orchestration": 20,
-      "Coordination & Service Discovery": 4,
-      "Remote Procedure Call": 1,
-      "Service Proxy": 5,
-      "API Gateway": 1,
-      "Service Mesh": 8,
-      "Database": 3,
-      "Streaming & Messaging": 5,
-      "Application Definition & Image Build": 22,
-      "Continuous Integration & Delivery": 8,
-      "Certified Kubernetes - Distribution": 1,
-      "Certified Kubernetes - Installer": 1,
-      "Tools": 1,
-      "Framework": 1,
-      "Installable Platform": 4,
-      "Monitoring": 12,
-      "Feature Flagging": 1,
-      "Logging": 1,
-      "Tracing": 3,
-      "Chaos Engineering": 3,
-      "Continuous Optimization": 1,
-      "Runtimes": 2
+      "Provisioning": {
+        "Automation & Configuration": 13,
+        "Container Registry": 4,
+        "Security & Compliance": 24,
+        "Key Management": 4
+      },
+      "Runtime": {
+        "Cloud Native Storage": 11,
+        "Container Runtime": 8,
+        "Cloud Native Network": 10
+      },
+      "Orchestration & Management": {
+        "Scheduling & Orchestration": 20,
+        "Coordination & Service Discovery": 4,
+        "Remote Procedure Call": 1,
+        "Service Proxy": 5,
+        "API Gateway": 1,
+        "Service Mesh": 8
+      },
+      "App Definition and Development": {
+        "Database": 3,
+        "Streaming & Messaging": 5,
+        "Application Definition & Image Build": 22,
+        "Continuous Integration & Delivery": 8
+      },
+      "Platform": {
+        "Certified Kubernetes - Distribution": 1,
+        "Certified Kubernetes - Installer": 1
+      },
+      "Serverless": {
+        "Tools": 1,
+        "Framework": 1,
+        "Installable Platform": 4
+      },
+      "Observability and Analysis": {
+        "Monitoring": 13,
+        "Feature Flagging": 1,
+        "Logging": 1,
+        "Tracing": 3,
+        "Chaos Engineering": 3,
+        "Continuous Optimization": 1
+      },
+      "Wasm": {
+        "Runtimes": 2
+      }
     }
   },
   "cncfSpecialSummary": {
@@ -72,13 +88,15 @@
       "Special": 312
     },
     "subcategoryBreakdown": {
-      "Kubernetes Certified Service Provider": 247,
-      "Kubernetes Training Partner": 59,
-      "Certified CNFs": 6
+      "Special": {
+        "Kubernetes Certified Service Provider": 247,
+        "Kubernetes Training Partner": 59,
+        "Certified CNFs": 6
+      }
     }
   },
   "cncfMembersSummary": {
-    "count": 817,
+    "count": 827,
     "commonKeys": [
       "item",
       "name",
@@ -89,15 +107,17 @@
     ],
     "uniqueKeys": "crunchbase,description,enduser,extra,extra.training_certifications,extra.training_type,joined,stock_ticker,twitter,unnamed_organization",
     "categoryBreakdown": {
-      "CNCF Members": 817
+      "CNCF Members": 827
     },
     "subcategoryBreakdown": {
-      "Platinum": 24,
-      "Gold": 25,
-      "Silver": 654,
-      "Academic": 4,
-      "Nonprofit": 20,
-      "End User Supporter": 90
+      "CNCF Members": {
+        "Platinum": 24,
+        "Gold": 25,
+        "Silver": 662,
+        "Academic": 4,
+        "Nonprofit": 20,
+        "End User Supporter": 92
+      }
     }
   },
   "cncfWasmSummary": {
@@ -115,22 +135,24 @@
       "Wasm": 126
     },
     "subcategoryBreakdown": {
-      "Languages": 16,
-      "Runtimes": 11,
-      "Application Frameworks": 15,
-      "Edge/Bare metal": 4,
-      "AI/Machine Learning": 7,
-      "Embedded Functions": 17,
-      "Tooling": 13,
-      "Orchestration & Management": 15,
-      "Hosted Platforms": 10,
-      "Decentralized Platforms": 10,
-      "Debugging & Observability": 3,
-      "Packaging, Registries & Application Delivery": 5
+      "Wasm": {
+        "Languages": 16,
+        "Runtimes": 11,
+        "Application Frameworks": 15,
+        "Edge/Bare metal": 4,
+        "AI/Machine Learning": 7,
+        "Embedded Functions": 17,
+        "Tooling": 13,
+        "Orchestration & Management": 15,
+        "Hosted Platforms": 10,
+        "Decentralized Platforms": 10,
+        "Debugging & Observability": 3,
+        "Packaging, Registries & Application Delivery": 5
+      }
     }
   },
   "nonCncfProjectsSummary": {
-    "count": 847,
+    "count": 856,
     "commonKeys": [
       "item",
       "name",
@@ -141,47 +163,61 @@
     ],
     "uniqueKeys": "additional_repos,additional_repos.0,additional_repos.0.repo_url,additional_repos.1,additional_repos.1.repo_url,additional_repos.2,additional_repos.2.repo_url,additional_repos.3,additional_repos.3.repo_url,additional_repos.4,additional_repos.4.repo_url,additional_repos.5,additional_repos.5.repo_url,additional_repos.6,additional_repos.6.repo_url,additional_repos.7,additional_repos.7.repo_url,allow_duplicate_repo,branch,crunchbase,description,extra,extra.accepted,extra.artwork_url,extra.blog_jp_url,extra.blog_url,extra.chat_channel,extra.clomonitor_name,extra.dev_stats_url,extra.discord_url,extra.docker_url,extra.github_discussions_url,extra.helm_chart_url,extra.kubernetes_url,extra.operator_chart_url,extra.parent_project,extra.slack_url,extra.stack_overflow_url,extra.summary_business_use_case,extra.summary_integration,extra.summary_integrations,extra.summary_intro_url,extra.summary_personas,extra.summary_release_rate,extra.summary_tags,extra.summary_use_case,extra.youtube_url,joined,open_source,organization,organization.name,project_org,repo_url,stock_ticker,twitter,url_for_bestpractices",
     "categoryBreakdown": {
-      "Provisioning": 129,
-      "Runtime": 88,
+      "Provisioning": 131,
+      "Runtime": 87,
       "Orchestration & Management": 83,
       "App Definition and Development": 194,
-      "Platform": 151,
+      "Platform": 155,
       "Serverless": 60,
-      "Observability and Analysis": 142
+      "Observability and Analysis": 146
     },
     "subcategoryBreakdown": {
-      "Automation & Configuration": 32,
-      "Container Registry": 9,
-      "Security & Compliance": 78,
-      "Key Management": 10,
-      "Cloud Native Storage": 59,
-      "Container Runtime": 11,
-      "Cloud Native Network": 18,
-      "Scheduling & Orchestration": 15,
-      "Coordination & Service Discovery": 5,
-      "Remote Procedure Call": 12,
-      "Service Proxy": 18,
-      "API Gateway": 20,
-      "Service Mesh": 13,
-      "Database": 71,
-      "Streaming & Messaging": 31,
-      "Application Definition & Image Build": 40,
-      "Continuous Integration & Delivery": 52,
-      "Certified Kubernetes - Distribution": 57,
-      "Certified Kubernetes - Hosted": 52,
-      "Certified Kubernetes - Installer": 21,
-      "PaaS/Container Service": 21,
-      "Security": 3,
-      "Tools": 9,
-      "Framework": 15,
-      "Hosted Platform": 23,
-      "Installable Platform": 10,
-      "Monitoring": 79,
-      "Feature Flagging": 2,
-      "Logging": 20,
-      "Tracing": 16,
-      "Chaos Engineering": 6,
-      "Continuous Optimization": 19
+      "Provisioning": {
+        "Automation & Configuration": 32,
+        "Container Registry": 9,
+        "Security & Compliance": 80,
+        "Key Management": 10
+      },
+      "Runtime": {
+        "Cloud Native Storage": 59,
+        "Container Runtime": 11,
+        "Cloud Native Network": 17
+      },
+      "Orchestration & Management": {
+        "Scheduling & Orchestration": 15,
+        "Coordination & Service Discovery": 5,
+        "Remote Procedure Call": 12,
+        "Service Proxy": 18,
+        "API Gateway": 20,
+        "Service Mesh": 13
+      },
+      "App Definition and Development": {
+        "Database": 72,
+        "Streaming & Messaging": 31,
+        "Application Definition & Image Build": 40,
+        "Continuous Integration & Delivery": 51
+      },
+      "Platform": {
+        "Certified Kubernetes - Distribution": 60,
+        "Certified Kubernetes - Hosted": 53,
+        "Certified Kubernetes - Installer": 21,
+        "PaaS/Container Service": 21
+      },
+      "Serverless": {
+        "Security": 3,
+        "Tools": 9,
+        "Framework": 15,
+        "Hosted Platform": 23,
+        "Installable Platform": 10
+      },
+      "Observability and Analysis": {
+        "Monitoring": 79,
+        "Feature Flagging": 6,
+        "Logging": 20,
+        "Tracing": 16,
+        "Chaos Engineering": 6,
+        "Continuous Optimization": 19
+      }
     }
   },
   "duplicateNames": false,

--- a/packages/cncf-common/src/index.ts
+++ b/packages/cncf-common/src/index.ts
@@ -4,4 +4,5 @@ export type {
   Category,
   CategoryStats,
   StatsCategoryBreakdown,
+  StatsSubcategoryBreakdown,
 } from './types';

--- a/packages/cncf-common/src/types.ts
+++ b/packages/cncf-common/src/types.ts
@@ -101,10 +101,14 @@ export interface StatsCategoryBreakdown {
   [key:string]: number;
 }
 
+export interface StatsSubcategoryBreakdown {
+  [key:string]: StatsCategoryBreakdown;
+}
+
 export interface CategoryStats {
   count: number;
   commonKeys: string[];
   uniqueKeys: string;
   categoryBreakdown: StatsCategoryBreakdown;
-  subcategoryBreakdown: StatsCategoryBreakdown;
+  subcategoryBreakdown: StatsSubcategoryBreakdown;
 }

--- a/scripts/landscape-yaml-parser/generateStats.ts
+++ b/scripts/landscape-yaml-parser/generateStats.ts
@@ -13,6 +13,7 @@ import {
   CategoryStats,
   LandscapeItem,
   StatsCategoryBreakdown,
+  StatsSubcategoryBreakdown,
 } from 'cncf-common';
 
 const fs = require('fs');
@@ -30,13 +31,20 @@ const generateStats = (items: LandscapeItem[]): CategoryStats => {
   }, {} as StatsCategoryBreakdown);
 
   const subcategoryBreakdown = items.reduce((acc, item) => {
-    if (acc.hasOwnProperty(item.subcategory)) {
-      acc[item.subcategory] = acc[item.subcategory] + 1;
+    const parentCategory = item.category;
+    const subcategory = item.subcategory;
+
+    if (!acc.hasOwnProperty(parentCategory)) {
+      acc[parentCategory] = {};
+    }
+
+    if (acc[parentCategory].hasOwnProperty(subcategory)) {
+      acc[parentCategory][subcategory] += 1;
     } else {
-      acc[item.subcategory] = 1;
+      acc[parentCategory][subcategory] = 1;
     }
     return acc;
-  }, {} as StatsCategoryBreakdown);
+  }, {} as StatsSubcategoryBreakdown);
 
   return {
     count: items.length,


### PR DESCRIPTION
#16 
## Motivation
With how `subcategoryBreakdown` was generated [before](https://github.com/minkimcello/landscape3/blob/e4b44277487bdae1cf2b6cb8cce5a1af6557efca/generated/landscape_stats.json#L27C1-L57C6), we were missing the information of what category each subcategory goes under. Now `subcategoryBreakdown` is [categorized](https://github.com/minkimcello/landscape3/blob/0d962ed5b48c786610def8bf6e4f89723842ba04/generated/landscape_stats.json#L27-L73) to display the number of projects by subcategory under each category. 

## Approach
An additional level is added to the `subcategoryBreakdown` object. Now each category is a key to `subcategoryBreakdown`, and its corresponding value is an object containing the breakdown of subcategories.