### PR TITLE
Update config for pull requests created by landscape-sync workflow

### DIFF
--- a/.github/workflows/landscape-sync.yml
+++ b/.github/workflows/landscape-sync.yml
@@ -28,9 +28,13 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          title: 🚀 Update Entities [automated]
           base: main
           branch: landscape-sync
-          body: Beep boop
           token: ${{ secrets.LANDSCAPE_TOKEN }}
-            # TODO: replace with bot
+          title: 🚀 Synchronize landscape.yml and regenerate entities [automated]
+          body: |
+            This pull request was created by the `landscape-sync` [workflow](https://github.com/minkimcello/landscape3/tree/main/.github/workflows).
+          author: "lucy-eade <lucy-eade@users.noreply.github.com>"
+          committer: "lucy-eade <lucy-eade@users.noreply.github.com>"
+          commit-message: |
+            Synchronize landscape.yml and update entities [automated]


### PR DESCRIPTION
## Motivation

Cats don't say `beep boop`. See #31.

## Approach

Commits were being signed by me even though the pull request was being created by Lucy. I saw in the [README](https://github.com/peter-evans/create-pull-request/blob/main/README.md?plain=1#L60-L61) that the committer and author defaults to the github action bot user and the person that triggered the workflow (respectively).

> Author writes the code and committer is the person that submits the commit ([stackoverflow](https://stackoverflow.com/questions/18750808/difference-between-author-and-committer-in-git)). I guess there are situations where those two are different? 🤷

If you look at [this workflow](https://github.com/minkimcello/landscape3/actions/runs/7734047327) that was triggered by cron, it lists me as the trigger...er. So I added Lucy as both the author and the committer.

Also updated the body, commit message, and title. I linked to the directory of where the workflows are (for the PR body) as opposed to linking directly to the workflow in case we end up changing the name of the file but forget to update the body.

---

We can also resolve #26 with this PR.